### PR TITLE
Addition of the timestamp in the microphone

### DIFF
--- a/Firmware/src_NRF/sensors/mic/mic_appl.c
+++ b/Firmware/src_NRF/sensors/mic/mic_appl.c
@@ -187,8 +187,8 @@ static void mic_streaming_thread(void *arg1, void *arg2, void *arg3) {
         int samples_remaining_in_packet = MIC_SAMPLES_PER_PACKET - packet_sample_offset;
         int samples_to_copy = MIN(samples_remaining_in_packet, num_samples - sample_idx);
 
-        /* Copy samples to packet (offset by 3 for header + counter) */
-        memcpy(&ble_packet[3 + (packet_sample_offset * MIC_BYTES_PER_SAMPLE)], &samples[sample_idx],
+        /* Copy samples to packet (offset by 7 for header + counter + timestamp) */
+        memcpy(&ble_packet[7 + (packet_sample_offset * MIC_BYTES_PER_SAMPLE)], &samples[sample_idx],
                samples_to_copy * MIC_BYTES_PER_SAMPLE);
 
         packet_sample_offset += samples_to_copy;

--- a/Firmware/src_NRF/sensors/mic/mic_appl.c
+++ b/Firmware/src_NRF/sensors/mic/mic_appl.c
@@ -200,6 +200,13 @@ static void mic_streaming_thread(void *arg1, void *arg2, void *arg3) {
           ble_packet[1] = (uint8_t)(packet_counter & 0xFF);
           ble_packet[2] = (uint8_t)((packet_counter >> 8) & 0xFF);
 
+          /* Add timestamp (microseconds) for synchronization */
+          uint32_t timestamp_us = k_cyc_to_us_floor32(k_cycle_get_32());
+          ble_packet[3] = (uint8_t)(timestamp_us & 0xFF);
+          ble_packet[4] = (uint8_t)((timestamp_us >> 8) & 0xFF);
+          ble_packet[5] = (uint8_t)((timestamp_us >> 16) & 0xFF);
+          ble_packet[6] = (uint8_t)((timestamp_us >> 24) & 0xFF);
+          
           ble_packet[MIC_PCKT_SIZE - 1] = MIC_DATA_TRAILER;
 
           /* Send via BLE queue */

--- a/Firmware/src_NRF/sensors/mic/mic_appl.c
+++ b/Firmware/src_NRF/sensors/mic/mic_appl.c
@@ -51,9 +51,9 @@ LOG_MODULE_REGISTER(mic_appl, LOG_LEVEL_INF);
  * Private Definitions
  *============================================================================*/
 
-/* Size of a block for 10 ms of audio data (reduced from 100ms for better interleaving) */
+/* Size of a block for 4ms ms of audio data */
 #define BLOCK_SIZE(_sample_rate, _number_of_channels)                                                                  \
-  (MIC_BYTES_PER_SAMPLE * ((_sample_rate) / 10) * (_number_of_channels))
+  (MIC_BYTES_PER_SAMPLE * ((_sample_rate) / 250) * (_number_of_channels))
 
 /* Maximum block size based on max sample rate and stereo */
 #define MAX_BLOCK_SIZE BLOCK_SIZE(MIC_MAX_SAMPLE_RATE, 2)

--- a/Firmware/src_NRF/sensors/mic/mic_appl.h
+++ b/Firmware/src_NRF/sensors/mic/mic_appl.h
@@ -81,10 +81,11 @@
  * Total MIC BLE packet size: 132 bytes
  * - Header: 1 byte
  * - Counter: 2 bytes
+ * - Timestamp: 4 bytes
  * - Audio data: 128 bytes (64 samples × 2 bytes)
  * - Trailer: 1 byte
  */
-#define MIC_PCKT_SIZE (1 + 2 + MIC_AUDIO_PAYLOAD_SIZE + 1)
+#define MIC_PCKT_SIZE (1 + 2 + 4 + MIC_AUDIO_PAYLOAD_SIZE + 1)
 
 /*==============================================================================
  * Type Definitions


### PR DESCRIPTION
This pull request updates the microphone BLE packet structure to include a timestamp for improved synchronization. The main changes involve adding a 4-byte timestamp to each packet, adjusting the packet size and memory offsets accordingly.

**Packet structure and synchronization improvements:**

* Added a 4-byte timestamp (in microseconds) to the BLE packet for synchronization purposes, and updated the packet size definition in `mic_appl.h` (`MIC_PCKT_SIZE` is now 1 + 2 + 4 + 128 + 1 = 136 bytes).
* Modified the packet construction in `mic_appl.c` to insert the timestamp after the header and counter, and adjusted the offset for copying audio samples to account for the new timestamp field.